### PR TITLE
Support component story format

### DIFF
--- a/generator/template/config/storybook/config.js
+++ b/generator/template/config/storybook/config.js
@@ -1,10 +1,4 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { configure } from '@storybook/vue'
 
-const req = require.context('../../src/stories', true, /.stories.js$/)
-
-function loadStories() {
-  req.keys().forEach(filename => req(filename))
-}
-
-configure(loadStories, module)
+configure(require.context('../../src', true, /\.stories\.(js|mdx)$/), module)


### PR DESCRIPTION
This updates story loading to support the Component Story Format (CSF).  It also updates the glob to scan for `.mdx` files.  The `storyOf` format is still supported, so this is likely not a breaking change.

The current method of loading stories does not support the Component Story Format or MDX.  Stories written with these newer methods do not appear in the UI without this change.