### PR TITLE
Allow docs-only parameter when building

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -17,6 +17,7 @@ const prodOptions = [
   ...sharedOptions,
   ['-o, --output-dir [dir-name]', 'Directory where to store built files'],
   ['-w, --watch', 'Enable watch mode'],
+  ['--docs', 'Build a documentation-only site using addon-docs'],
 ];
 
 // Parsed from storybook repo.


### PR DESCRIPTION
Fix #91