### PR TITLE
Prevent global CSS imports from being removed by storybook-build

### DIFF
--- a/lib/preset.js
+++ b/lib/preset.js
@@ -20,6 +20,8 @@ module.exports = {
 
     chainableConfig.module.rule('eslint').exclude.add(api.resolve('config/storybook')).end();
     chainableConfig.module.rule('js').uses.delete('thread-loader');
+    // Prevent global CSS imports from being removed by storybook-build
+    chainableConfig.module.rule('css').set('sideEffects', true);
 
     const webpackConfig = api.resolveWebpackConfig(chainableConfig);
 


### PR DESCRIPTION
In my Storybook `preview.js` config, I import a global CSS file like this:

```js
import '@/assets/tailwind.css';
```

This works perfectly fine in development, the style is visible. However when running `vue-cli-service storybook:build`, the style disappear.

My research leaded me to this line (https://github.com/storybookjs/storybook/blob/next/lib/core/src/server/preview/base-webpack.config.js#L49) in the Storybook default CSS loader. For some reasons it seems to be the tiny little bit missing to prevent the code from being removed from the final bundle in production mode.

So here’s a proposition to add it to Vue CLI own CSS rule so global CSS stays.