### PR TITLE
Use correct hierarchy separator for storybook 6

### DIFF
--- a/generator/template/src/stories/index.stories.mdx
+++ b/generator/template/src/stories/index.stories.mdx
@@ -6,7 +6,7 @@ import { linkTo } from '@storybook/addon-links'
 <%_ } _%>
 import MyButton from '../components/MyButton.vue';
 
-<Meta title="MDX|Button" component={MyButton} />
+<Meta title="MDX / Button" component={MyButton} />
 
 # Button
 


### PR DESCRIPTION
Currently a folder `MDX|Button` is created. Instead a section `MDX` with folder `Button` should be there.

Warning from the console:
> The default hierarchy separators changed in Storybook 6.0.
> '|' and '.' will no longer create a hierarchy, but codemods are available.
> Read more about it in the migration guide: https://github.com/storybookjs/storybook/blob/master/MIGRATION.md