### PR TITLE
Use vue-cli-5 with webpack-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Vue CLI plugin for Storybook
 $ vue add storybook
 ```
 
+Or to install the next major version for vue-cli-5, please run
+
+```
+$ vue add storybook@next
+```
+
 <p align=center><img src=screencast.svg width=600></p>
 
 ## Usage

--- a/generator/index.js
+++ b/generator/index.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 module.exports = (api, options, rootOptions) => {
-  api.assertCliVersion('>=4');
+  api.assertCliVersion('>=5');
   const isVue3 = (rootOptions.vueVersion === '3');
 
   // eslint-disable-next-line import/no-dynamic-require, global-require
@@ -22,8 +22,10 @@ module.exports = (api, options, rootOptions) => {
       'storybook:build': 'vue-cli-service storybook:build -c config/storybook',
     },
     devDependencies: {
-      [frameworkSupport]: params.versionRange,
       '@storybook/addon-essentials': params.versionRange,
+      '@storybook/builder-webpack5': params.versionRange,
+      '@storybook/manager-webpack5': params.versionRange,
+      [frameworkSupport]: params.versionRange,
     },
   });
 

--- a/generator/template/config/storybook/main.js
+++ b/generator/template/config/storybook/main.js
@@ -1,4 +1,7 @@
 module.exports = {
+  core: {
+    builder: 'webpack5',
+  },
   stories: ['../../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
   addons: ['@storybook/addon-essentials', '@storybook/addon-links']
 }

--- a/generator/template/src/stories/index.stories.mdx
+++ b/generator/template/src/stories/index.stories.mdx
@@ -1,9 +1,6 @@
 
 import { Meta, ArgsTable, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions'
-<%_ if (hasBabel) { _%>
-import { linkTo } from '@storybook/addon-links'
-<%_ } _%>
 import MyButton from '../components/MyButton.vue';
 
 <Meta title="MDX / Button" component={MyButton} />
@@ -23,14 +20,6 @@ This is a simple button with some text in it.
     }}
   </Story>
 </Canvas>
-
-<%_ if (hasBabel) { _%>
-You can perform some action when the button is clicked.
-
-<Canvas>
-  <RMyButton onClick={linkTo('Button', 'With Some Emoji')}>With JSX</RMyButton>
-</Canvas>
-<%_ } _%>
 
 You can even have Emoji in the button.
 

--- a/lib/preset.js
+++ b/lib/preset.js
@@ -41,6 +41,10 @@ module.exports = {
           ...webpackConfig.resolve && webpackConfig.resolve.alias,
           vue$: require.resolve(vueModule),
         },
+        fallback: {
+          ...webpackConfig.resolve && webpackConfig.resolve.fallback,
+          path: require.resolve('path-browserify'),
+        },
       },
       resolveLoader: webpackConfig.resolveLoader,
     };

--- a/migrator/index.js
+++ b/migrator/index.js
@@ -1,0 +1,14 @@
+const selectWebpack5 = require('./selectWebpack5');
+
+module.exports = (api) => {
+  if (api.fromVersion('~2')) {
+    const semver = '^6.4.3';
+    api.extendPackage({
+      devDependencies: {
+        '@storybook/builder-webpack5': semver,
+        '@storybook/manager-webpack5': semver,
+      },
+    });
+    api.transformScript(api.resolve('config/storybook/main.js'), selectWebpack5);
+  }
+};

--- a/migrator/selectWebpack5.js
+++ b/migrator/selectWebpack5.js
@@ -1,0 +1,18 @@
+module.exports = (file, api) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  root
+    .find(j.AssignmentExpression, {
+      left: {
+        type: 'MemberExpression',
+        object: { name: 'module' },
+        property: { name: 'exports' },
+      },
+    })
+    .forEach((path) => path.value.right.properties.push(
+      j.property('init', j.identifier('core'), j.objectExpression([
+        j.property('init', j.identifier('builder'), j.literal('webpack5')),
+      ])),
+    ));
+  return root.toSource();
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-storybook",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Vue CLI plugin for Storybook",
   "main": "./lib/index.js",
   "scripts": {
@@ -26,7 +26,7 @@
     "chalk": "^3.0.0",
     "commander": "^2.19.0",
     "semver": "^7.1.1",
-    "@vue/cli-shared-utils": "^4.4.6"
+    "@vue/cli-shared-utils": "^5.0.0-rc.1"
   },
   "peerDependencies": {
     "@storybook/vue": ">=6.0.0",
@@ -41,7 +41,7 @@
     }
   },
   "devDependencies": {
-    "@vue/cli": "^4",
+    "@vue/cli": "^5.0.0-rc.1",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.19.0"

--- a/prompts.js
+++ b/prompts.js
@@ -17,15 +17,15 @@ module.exports = [
     when: (answers) => answers.type === 'init',
     name: 'semver',
     type: 'input',
-    default: '^6.0.26',
+    default: '^6.4.3',
     message: `What storybook version do you want? ${chalk.yellow('(Please specify semver range)')}`,
     validate: (input) => {
       if (input === '' || !semver.validRange(input)) {
         return 'Given semver range is not valid.';
       }
 
-      if (!semver.prerelease(input) && !semver.intersects(input, '>=6.0.0')) {
-        return 'Minimum supported storybook version is 6.0.0';
+      if (!semver.prerelease(input) && !semver.intersects(input, '>=6.2.0')) {
+        return 'Minimum supported storybook version is 6.2.0';
       }
 
       return true;

--- a/test/test.sh
+++ b/test/test.sh
@@ -7,6 +7,6 @@ npm pack .
 npx vue create --preset test/preset.json tmp
 cd tmp
 npm i ../*.tgz
-npx vue invoke storybook --type init --semver '^6.0.1'
+npx vue invoke storybook --type init --semver '^6.4.3'
 npm i
 npx chromatic test --build-script-name='storybook:build' --exit-zero-on-changes --no-interactive --debug


### PR DESCRIPTION
New major version, which only supports vue-cli-5.

We should probably release this under the `@next` tag. Then anybody with vue-cli-5 can install it as `vue add storybook@next` and for vue-cli-4 the usual `vue add storybook` still works. Add this to the readme?
Later when vue-cli-5 is final, we can switch to latest tag and vue-cli-4 users can still use the integration with `vue add storybook@^2`.

Resolves #118.