### PR TITLE
Support Storybook >= 6.5 core server

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,17 @@
-// eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies
-const server = require('@storybook/core/server');
+/* eslint-disable import/no-unresolved, import/no-extraneous-dependencies, global-require */
+let server;
+try {
+  // Storybook < 6.5 syntax
+  server = require('@storybook/core/server');
+} catch (e) {
+  if (e.code !== 'MODULE_NOT_FOUND') {
+    throw e;
+  }
+  // Storybook >= 6.5 syntax
+  server = require('@storybook/core-server');
+}
+/* eslint-enable import/no-unresolved, import/no-extraneous-dependencies, global-require */
+
 const isVue3 = require('./isVue3');
 
 // eslint-disable-next-line import/no-unresolved


### PR DESCRIPTION
This PR adds support for the new import path of the core SB server, starting from the 6.5 branch. It partially fixes #128.

Tested with 6.5.10 and 6.4.19.